### PR TITLE
Override toctree helper to generate valid links

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "common"]
 	path = common
-	url = git@github.com:rtfd/common.git
+	url = https://github.com/rtfd/common

--- a/notfound/extension.py
+++ b/notfound/extension.py
@@ -1,12 +1,5 @@
 import os
-
 import docutils
-from sphinx.builders.html import TocTree
-from sphinx.errors import ExtensionError
-
-
-class BaseURIError(ExtensionError):
-    pass
 
 
 # https://www.sphinx-doc.org/en/stable/extdev/appapi.html#event-html-collect-pages
@@ -30,6 +23,14 @@ def html_collect_pages(app):
 
 def finalize_media(app, pagename, templatename, context, doctree):
     """Point media files at our media server."""
+
+    # Import these here so we can use ``app.require_sphinx`` method in the
+    # ``setup`` and limit to greater versions of Sphinx
+    from sphinx.environment.adapters.toctree import TocTree
+    from sphinx.errors import ExtensionError
+
+    class BaseURIError(ExtensionError):
+        pass
 
     # https://github.com/sphinx-doc/sphinx/blob/7138d03ba033e384f1e7740f639849ba5f2cc71d/sphinx/builders/html.py#L1054-L1065
     def pathto(otheruri, resource=False, baseuri=None):
@@ -109,6 +110,8 @@ def setup(app):
         # TODO: improve the default ``body``
         'body': '<h1>Page not found</h1>\n\nThanks for trying.',
     }
+
+    app.require_sphinx('1.6')
 
     # https://github.com/sphinx-doc/sphinx/blob/master/sphinx/themes/basic/page.html
     app.add_config_value('notfound_template', 'page.html', 'html')

--- a/notfound/extension.py
+++ b/notfound/extension.py
@@ -1,5 +1,6 @@
-import docutils
 import os
+
+import docutils
 from sphinx.builders.html import TocTree
 from sphinx.errors import ExtensionError
 
@@ -69,7 +70,6 @@ def finalize_media(app, pagename, templatename, context, doctree):
         uri = otheruri or '#'
         return uri
 
-
     # https://github.com/sphinx-doc/sphinx/blob/2adeb68af1763be46359d5e808dae59d708661b1/sphinx/builders/html.py#L1081
     def toctree(*args, **kwargs):
         toc = TocTree(app.env).get_toctree_for(
@@ -91,7 +91,6 @@ def finalize_media(app, pagename, templatename, context, doctree):
 
         return app.builder.render_partial(toc)['fragment']
 
-
     # Apply our custom manipulation to 404.html page only
     if pagename == app.config.notfound_pagename:
         # Override the ``pathto`` helper function from the context to use a custom ones
@@ -103,7 +102,6 @@ def finalize_media(app, pagename, templatename, context, doctree):
         # https://www.sphinx-doc.org/en/master/templating.html#toctree
         # NOTE: not used on ``singlehtml`` builder for RTD Sphinx theme
         context['toctree'] = toctree
-        # context['toctree'] = lambda *args, **kwargs: toctree(app, *args, **kwargs)
 
 
 def setup(app):

--- a/notfound/extension.py
+++ b/notfound/extension.py
@@ -88,6 +88,10 @@ def finalize_media(app, pagename, templatename, context, doctree):
                       # Python2 syntax
         )
 
+        # If no TOC is found, just return ``None`` instead of failing here
+        if not toc:
+            return None
+
         # https://github.com/sphinx-doc/sphinx/blob/2adeb68af1763be46359d5e808dae59d708661b1/sphinx/environment/adapters/toctree.py#L260-L266
         for refnode in toc.traverse(docutils.nodes.reference):
             refuri = '/{language}/{version}/{filename}'.format(

--- a/notfound/extension.py
+++ b/notfound/extension.py
@@ -1,4 +1,5 @@
 import docutils
+import os
 from sphinx.builders.html import TocTree
 from sphinx.errors import ExtensionError
 
@@ -82,8 +83,8 @@ def finalize_media(app, pagename, templatename, context, doctree):
         # https://github.com/sphinx-doc/sphinx/blob/2adeb68af1763be46359d5e808dae59d708661b1/sphinx/environment/adapters/toctree.py#L260-L266
         for refnode in toc.traverse(docutils.nodes.reference):
             refuri = '/{language}/{version}/{filename}'.format(
-                language=app.config.notfound_default_language,
-                version=app.config.notfound_default_version,
+                language=app.config.language or 'en',
+                version=os.environ.get('READTHEDOCS_VERSION', 'latest'),
                 filename=refnode.attributes.get('refuri'),  # somepage.html
             )
             refnode.replace_attr('refuri', refuri)

--- a/notfound/extension.py
+++ b/notfound/extension.py
@@ -84,7 +84,8 @@ def finalize_media(app, pagename, templatename, context, doctree):
             app.builder,
             collapse=kwargs.pop('collapse', False),
             includehidden=kwargs.pop('includehidden', False),
-            **kwargs,
+            **kwargs  # not using trailing comma here makes this compatible with
+                      # Python2 syntax
         )
 
         # https://github.com/sphinx-doc/sphinx/blob/2adeb68af1763be46359d5e808dae59d708661b1/sphinx/environment/adapters/toctree.py#L260-L266

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setuptools.setup(
     author='Manuel Kaufmann',
     author_email='humitos@gmail.com',
     description='Sphinx extension to build a 404 page with absolute URLs',
-    url='https://github.com/humitos/sphinx-notfound-page',
+    url='https://github.com/rtfd/sphinx-notfound-page',
     packages=setuptools.find_packages(),
     long_description=long_description,
     long_description_content_type='text/x-rst',

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,6 @@ setuptools.setup(
         'Operating System :: OS Independent',
     ],
     install_requires=[
-        'sphinx>=1.6',
+        'sphinx',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,6 @@ setuptools.setup(
         'Operating System :: OS Independent',
     ],
     install_requires=[
-        'sphinx',
+        'sphinx>=1.6',
     ],
 )


### PR DESCRIPTION
`toctree` helper does not use `pathto` helper to generate the links to
the other documents. So, we need to override the Sphinx's internals
where the toctree is generated and modify the refuri for each node of
the toctree after it's generated.

Our custom function uses the internal TocTree class from Sphinx but
after the toctree is generated it traverses it looking for reference
nodes and replace the refuri.

Live and working example at: https://test-builds.readthedocs.io/en/custom-404-page/not/found/page/with/subpath.html

Closes #6 