### PR TITLE
Resolve internal Sphinx javascript resources URLs

### DIFF
--- a/notfound/extension.py
+++ b/notfound/extension.py
@@ -1,5 +1,6 @@
 import os
 import docutils
+import sphinx
 
 from sphinx.errors import ExtensionError
 
@@ -147,3 +148,12 @@ def setup(app):
 
     app.connect('html-collect-pages', html_collect_pages)
     app.connect('html-page-context', finalize_media)
+
+    # Sphinx injects some javascript files using ``add_js_file``. The path for
+    # this file is rendered in the template using ``js_tag`` instead of
+    # ``pathto``. The ``js_tag`` uses ``pathto`` internally to resolve these
+    # paths, we call again the setup function for this tag *after* the context
+    # was overriden by our extension with the patched ``pathto`` function.
+    if sphinx.version_info >= (1, 8):
+        from sphinx.builders.html import setup_js_tag_helper
+        app.connect('html-page-context', setup_js_tag_helper)

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -1,5 +1,6 @@
 import os
 import pytest
+import sphinx
 
 
 srcdir = os.path.join(
@@ -290,6 +291,30 @@ def test_custom_404_rst_source(app, status, warning):
         '<link rel="stylesheet" href="/en/latest/_static/pygments.css" type="text/css" />',
         '<link rel="stylesheet" href="/en/latest/_static/custom.css" type="text/css" />',
     ]
+
+    for chunk in chunks:
+        assert chunk in content
+
+
+@pytest.mark.sphinx(srcdir=srcdir)
+def test_sphinx_resource_urls(app, status, warning):
+    app.build()
+    path = app.outdir / '404.html'
+    assert path.exists() == True
+
+    content = open(path).read()
+
+    chunks = [
+        # Sphinx's resources URLs
+        '<script type="text/javascript" src="/en/latest/_static/jquery.js"></script>',
+        '<script type="text/javascript" src="/en/latest/_static/underscore.js"></script>',
+        '<script type="text/javascript" src="/en/latest/_static/doctools.js"></script>',
+    ]
+
+    if sphinx.version_info >= (1, 8):
+        chunks.append(
+            '<script type="text/javascript" src="/en/latest/_static/language_data.js"></script>',
+        )
 
     for chunk in chunks:
         assert chunk in content


### PR DESCRIPTION
Sphinx adds some common javascript file to all the pages rendered. These files are rendered using a template tag called `js_tag` that it's registered inside a an event.

Since the function connected to this event is called after our extension re-defines the `pathto` function in the context, we need to re-connect the same function to redefine the `js_tag` but now with our own patched `pathto` function.

Close #26 