### PR TITLE
Allow using image directive with non-local images

### DIFF
--- a/notfound/utils.py
+++ b/notfound/utils.py
@@ -37,7 +37,7 @@ def replace_uris(app, doctree, nodetype, nodeattr):
 
         if re.match('^https?://', uri):
             # allow non-local URLs for resources
-            return
+            continue
 
         imagedir = ''
         if nodetype is docutils.nodes.image:

--- a/notfound/utils.py
+++ b/notfound/utils.py
@@ -1,4 +1,5 @@
 import docutils
+import re
 from sphinx.builders.html import DirectoryHTMLBuilder
 
 
@@ -33,6 +34,10 @@ def replace_uris(app, doctree, nodetype, nodeattr):
             # initial ``../`` to make valid links
             if uri.startswith('../'):
                 uri = uri.replace('../', '')
+
+        if re.match('^https?://', uri):
+            # allow non-local URLs for resources
+            return
 
         imagedir = ''
         if nodetype is docutils.nodes.image:

--- a/tests/examples/404rst/404.rst
+++ b/tests/examples/404rst/404.rst
@@ -33,3 +33,7 @@ Including an image using an absolute URL should not be modified by the extension
 
 .. image:: https://read-the-docs-guidelines.readthedocs-hosted.com/_images/logo-dark.png
    :alt: Read the Docs Logo
+
+
+.. image:: https.png
+   :alt: PATH looking as an URL

--- a/tests/examples/404rst/404.rst
+++ b/tests/examples/404rst/404.rst
@@ -27,3 +27,9 @@ Also, using ``.. figure::`` should work as well.
 .. figure:: test.png
 
    Description.
+
+
+Including an image using an absolute URL should not be modified by the extension:
+
+.. image:: https://read-the-docs-guidelines.readthedocs-hosted.com/_images/logo-dark.png
+   :alt: Read the Docs Logo

--- a/tests/examples/404rst/https.png
+++ b/tests/examples/404rst/https.png
@@ -1,0 +1,1 @@
+This is just a file to be found by Sphinx when using ".. figure::" and do not fail.

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -344,6 +344,25 @@ def test_image_on_404_rst_source(app, status, warning):
 
 
 @pytest.mark.sphinx(srcdir=rstsrcdir)
+def test_image_looks_like_absolute_url(app, status, warning):
+    app.build()
+
+    path = app.outdir / '_images' / 'https.png'
+    assert path.exists()
+
+    path = app.outdir / '404.html'
+    assert path.exists()
+    content = open(path).read()
+
+    chunks = [
+        '<img alt="PATH looking as an URL" src="/en/latest/_images/https.png" />',
+    ]
+
+    for chunk in chunks:
+        assert chunk in content
+
+
+@pytest.mark.sphinx(srcdir=rstsrcdir)
 def test_image_absolute_url(app, status, warning):
     app.build()
     path = app.outdir / '404.html'

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -343,6 +343,21 @@ def test_image_on_404_rst_source(app, status, warning):
         assert chunk in content
 
 
+@pytest.mark.sphinx(srcdir=rstsrcdir)
+def test_image_absolute_url(app, status, warning):
+    app.build()
+    path = app.outdir / '404.html'
+    assert path.exists() == True
+    content = open(path).read()
+
+    chunks = [
+        '<img alt="Read the Docs Logo" src="https://read-the-docs-guidelines.readthedocs-hosted.com/_images/logo-dark.png" />',
+    ]
+
+    for chunk in chunks:
+        assert chunk in content
+
+
 @pytest.mark.sphinx(
     srcdir=srcdir,
     buildername='dirhtml',


### PR DESCRIPTION
This PR supports the usage of this directive,

    .. image:: https://path.to/image.png

It won't prefix that full URL with language and version.