### PR TITLE
Don't list sphinx as a requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,4 @@ setuptools.setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
     ],
-    install_requires=[
-        'sphinx',
-    ],
 )


### PR DESCRIPTION
This can lead to modify a pinned sphinx version by the user.
Extensions shouldn't list Sphinx as requirement.