### PR TITLE
Run tox docs with -W

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -27,4 +27,4 @@ deps =
   .
 changedir = {toxinidir}/docs
 commands =
-    sphinx-build -q -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
+    sphinx-build -q -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html


### PR DESCRIPTION
This makes the docs test to fail if there is a WARNING.