### PR TITLE
adds pyPI, docs, and license badges to readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-|PyPI version| |Docs badge| |License|
+|Build| |PyPI version| |Docs badge| |License|
 
 sphinx-notfound-page
 ====================
@@ -39,10 +39,15 @@ Thanks
 
 **Strongly** based on @ericholscher's solution from https://github.com/rtfd/readthedocs.org/issues/353
 
+.. |Build| image:: https://travis-ci.org/rtfd/sphinx-notfound-page.svg?branch=master
+    :target: https://travis-ci.org/rtfd/sphinx-notfound-page
+    :alt: Build status
 .. |PyPI version| image:: https://img.shields.io/pypi/v/sphinx-notfound-page.svg
    :target: https://pypi.org/project/sphinx-notfound-page
-.. |Docs badge| image:: https://img.shields.io/badge/docs-latest-brightgreen.svg
-   :target: https://sphinx-notfound-page.readthedocs.io/en/latest/
+   :alt: Current PyPI version
+.. |Docs badge| .. image:: https://readthedocs.org/projects/sphinx-notfound-page/badge/?version=latest
+   :target: https://sphinx-notfound-page.readthedocs.io/en/latest/?badge=latest
+   :alt: Documentation status
 .. |License| image:: https://img.shields.io/github/license/rtfd/sphinx-notfound-page.svg
    :target: LICENSE
-   :alt: Repository License
+   :alt: Repository license

--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ Thanks
 
 **Strongly** based on @ericholscher's solution from https://github.com/rtfd/readthedocs.org/issues/353
 
-.. |PyPI version| https://img.shields.io/pypi/v/sphinx-notfound-page.svg
+.. |PyPI version| image:: https://img.shields.io/pypi/v/sphinx-notfound-page.svg
    :target: https://pypi.org/project/sphinx-notfound-page
 .. |Docs badge| image:: https://img.shields.io/badge/docs-latest-brightgreen.svg
    :target: https://sphinx-notfound-page.readthedocs.io/en/latest/

--- a/README.rst
+++ b/README.rst
@@ -40,8 +40,8 @@ Thanks
 **Strongly** based on @ericholscher's solution from https://github.com/rtfd/readthedocs.org/issues/353
 
 .. |Build| image:: https://travis-ci.org/rtfd/sphinx-notfound-page.svg?branch=master
-    :target: https://travis-ci.org/rtfd/sphinx-notfound-page
-    :alt: Build status
+   :target: https://travis-ci.org/rtfd/sphinx-notfound-page
+   :alt: Build status
 .. |PyPI version| image:: https://img.shields.io/pypi/v/sphinx-notfound-page.svg
    :target: https://pypi.org/project/sphinx-notfound-page
    :alt: Current PyPI version

--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ Thanks
 .. |PyPI version| image:: https://img.shields.io/pypi/v/sphinx-notfound-page.svg
    :target: https://pypi.org/project/sphinx-notfound-page
    :alt: Current PyPI version
-.. |Docs badge| .. image:: https://readthedocs.org/projects/sphinx-notfound-page/badge/?version=latest
+.. |Docs badge| image:: https://readthedocs.org/projects/sphinx-notfound-page/badge/?version=latest
    :target: https://sphinx-notfound-page.readthedocs.io/en/latest/?badge=latest
    :alt: Documentation status
 .. |License| image:: https://img.shields.io/github/license/rtfd/sphinx-notfound-page.svg

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,5 @@
+|PyPI version| |Docs badge| |License|
+
 sphinx-notfound-page
 ====================
 
@@ -36,3 +38,11 @@ Thanks
 ------
 
 **Strongly** based on @ericholscher's solution from https://github.com/rtfd/readthedocs.org/issues/353
+
+.. |PyPI version| https://img.shields.io/pypi/v/sphinx-notfound-page.svg
+   :target: https://pypi.org/project/sphinx-notfound-page
+.. |Docs badge| image:: https://img.shields.io/badge/docs-latest-brightgreen.svg
+   :target: https://sphinx-notfound-page.readthedocs.io/en/latest/
+.. |License| image:: https://img.shields.io/github/license/rtfd/sphinx-notfound-page.svg
+   :target: LICENSE
+   :alt: Repository License


### PR DESCRIPTION
Adds badges from https://shields.io/ to the README page on GitHub for the PyPI package, the docsite, and the license.

Partial fix for #36. 

I believe the project's tests are running on Travis, but I couldn't find the right combination of username and project to get a badge - I kept getting "unknown" as the status (see https://shields.io/category/build). So I did not add a build badge. 