### PR TITLE
Adds badges to docs index page

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-|Build| |PyPI version| |Docs badge| |License|
+|Build| |PyPI| |License| |Docs|
 
 sphinx-notfound-page
 ====================
@@ -42,12 +42,12 @@ Thanks
 .. |Build| image:: https://travis-ci.org/rtfd/sphinx-notfound-page.svg?branch=master
    :target: https://travis-ci.org/rtfd/sphinx-notfound-page
    :alt: Build status
-.. |PyPI version| image:: https://img.shields.io/pypi/v/sphinx-notfound-page.svg
+.. |PyPI| image:: https://img.shields.io/pypi/v/sphinx-notfound-page.svg
    :target: https://pypi.org/project/sphinx-notfound-page
    :alt: Current PyPI version
-.. |Docs badge| image:: https://readthedocs.org/projects/sphinx-notfound-page/badge/?version=latest
-   :target: https://sphinx-notfound-page.readthedocs.io/en/latest/?badge=latest
-   :alt: Documentation status
 .. |License| image:: https://img.shields.io/github/license/rtfd/sphinx-notfound-page.svg
    :target: LICENSE
    :alt: Repository license
+.. |Docs| image:: https://readthedocs.org/projects/sphinx-notfound-page/badge/?version=latest
+  :target: https://sphinx-notfound-page.readthedocs.io/en/latest/?badge=latest
+  :alt: Documentation status

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,37 +1,24 @@
-|Build| |PyPI version| |License|
+|Build| |PyPI| |License| |Issues|
 
 Welcome to sphinx-notfound-page!
 ================================
 
-``sphinx-notfound-page`` is a Sphinx_ extension to create custom 404 pages and help you to generate proper resource links (js, css, images, etc) to render the page properly.
+``sphinx-notfound-page`` is a Sphinx_ extension to create custom 404 pages and generate proper resource links (js, css, images, etc) to render the page properly.
 
-This extension was originally developed to be used on `Read the Docs`_ but it can be used in other hosting services as well.
-
-Online documentation:
-    https://sphinx-notfound-page.readthedocs.io/
+This extension was originally developed to be used on `Read the Docs`_, but it can be used in other documentation hosting services as well.
 
 Source code repository (and issue tracker):
     https://github.com/rtfd/sphinx-notfound-page/
 
-License:
-    MIT
+Why do I need this extension?
+-----------------------------
 
+Sphinx does not create a 404 page by default. You can create one by adding a
+``404.rst`` file to your docs, but on the resulting ``404.html`` page the
+links  to images, stylesheets, and javascript resources will be broken.
 
-Why I need this extension?
---------------------------
-
-Sphinx does not create a 404 page by default.
-Although, you can create it by adding a simple ``404.rst`` file to your docs but...
-
-If you are reading this documentation,
-you may already experienced the problem that all your images do no load,
-all your styles are broken and all the javascript events does not work,
-when accessing the 404 page of your documentation.
-
-So, if you want to have a nice custom 404 page,
-you will probably want to use this extension to avoid this headache
-and let the extension handle these URLs properly for you.
-
+Use the ``sphinx-notfound-page`` extension to handle these URLs properly for
+you, creating a custom 404 page that works seamlessly and easily.
 
 
 .. toctree::
@@ -59,9 +46,12 @@ and let the extension handle these URLs properly for you.
 .. |Build| image:: https://travis-ci.org/rtfd/sphinx-notfound-page.svg?branch=master
    :target: https://travis-ci.org/rtfd/sphinx-notfound-page
    :alt: Build status
-.. |PyPI version| image:: https://img.shields.io/pypi/v/sphinx-notfound-page.svg
+.. |PyPI| image:: https://img.shields.io/pypi/v/sphinx-notfound-page.svg
    :target: https://pypi.org/project/sphinx-notfound-page
    :alt: Current PyPI version
 .. |License| image:: https://img.shields.io/github/license/rtfd/sphinx-notfound-page.svg
    :target: LICENSE
    :alt: Repository license
+.. |Issues| image:: https://img.shields.io/github/issues/rtfd/sphinx-notfound-page.svg
+   :target: https://github.com/rtfd/sphinx-notfound-page/issues
+   :alt: Open issues

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,3 +1,5 @@
+|Build| |PyPI version| |License|
+
 Welcome to sphinx-notfound-page!
 ================================
 
@@ -53,3 +55,13 @@ and let the extension handle these URLs properly for you.
 
 .. _Sphinx: https://www.sphinx-doc.org/
 .. _Read the Docs: https://readthedocs.org
+
+.. |Build| image:: https://travis-ci.org/rtfd/sphinx-notfound-page.svg?branch=master
+   :target: https://travis-ci.org/rtfd/sphinx-notfound-page
+   :alt: Build status
+.. |PyPI version| image:: https://img.shields.io/pypi/v/sphinx-notfound-page.svg
+   :target: https://pypi.org/project/sphinx-notfound-page
+   :alt: Current PyPI version
+.. |License| image:: https://img.shields.io/github/license/rtfd/sphinx-notfound-page.svg
+   :target: LICENSE
+   :alt: Repository license


### PR DESCRIPTION
Closes #36.

Adds badges for Build, PyPI, License, and Issues to docs index page.
Removes inline links to those same resources from docs index page.
Edits docs index page text.
Updates badges on README for brevity. 